### PR TITLE
Avoid redundant nominal JEC debug messages for systematic shifts

### DIFF
--- a/applyJercAndJvmOnNano.C
+++ b/applyJercAndJvmOnNano.C
@@ -949,15 +949,25 @@ static void processEvents(const std::string& inputFile,
         printDebug(print, 3, "MET From NanoAOD = ", nanoT.MET_pt);
 
         // =========================
-        // 1) JES (nominal only here) — NO JER inside
+        // 1) JES (nominal) — NO JER inside
         // =========================
-        printDebug(print, 3, "AK4 (JES nominal)");
-        applyNominalCorrections<AK4Specs>(nanoT, refsAK4, isData, indicesAK4, print);
+        if (systTagDetail.isNominal()) {
+            // In the nominal pass print the full per-jet breakdown
+            printDebug(print, 3, "AK4 (JES nominal)");
+            applyNominalCorrections<AK4Specs>(nanoT, refsAK4, isData, indicesAK4, print);
 
-        printDebug(print, 3, "AK8 (JES nominal)");
-        applyNominalCorrections<AK8Specs>(nanoT, refsAK8, isData, indicesAK8, print);
+            printDebug(print, 3, "AK8 (JES nominal)");
+            applyNominalCorrections<AK8Specs>(nanoT, refsAK8, isData, indicesAK8, print);
 
-        printDebug(print, 3, "MET After (JES nominal) = ", nanoT.MET_pt);
+            printDebug(print, 3, "MET After (JES nominal) = ", nanoT.MET_pt);
+        } else {
+            // For systematic shifts we still need to apply the nominal
+            // corrections but skip the verbose printing to avoid repeating
+            // the same information for each shift.
+            applyNominalCorrections<AK4Specs>(nanoT, refsAK4, isData, indicesAK4, false);
+            applyNominalCorrections<AK8Specs>(nanoT, refsAK8, isData, indicesAK8, false);
+            printDebug(print, 3, "Nominal JEC applied");
+        }
 
         // =========================
         // 2) JES Uncertainty (MC only), if this pass is JES


### PR DESCRIPTION
## Summary
- Suppress verbose nominal JEC debug output during systematic passes
- Print a concise `Nominal JEC applied` message before each systematic shift

## Testing
- `root -b applyJercAndJvmOnNano.C -q` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b32fc88a0832f8a2d27640f248d61